### PR TITLE
Await `skip` method because it is async in router

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
     strict: "error",
   },
   parserOptions: {
-    ecmaVersion: 8
+    ecmaVersion: 8,
   },
   overrides: [
     {

--- a/lib/express-rate-limit.js
+++ b/lib/express-rate-limit.js
@@ -50,7 +50,7 @@ function RateLimit(options) {
   });
 
   async function rateLimit(req, res, next) {
-    if (options.skip(req, res)) {
+    if (await options.skip(req, res)) {
       return next();
     }
 


### PR DESCRIPTION
The `skip` method in our apps is async, so changed our implementation to be await it's response